### PR TITLE
most recently used chat is automatically loaded when possible

### DIFF
--- a/frontend/src/components/PrevChatSideBar.tsx
+++ b/frontend/src/components/PrevChatSideBar.tsx
@@ -3,6 +3,7 @@ import "../styles/PrevChatSideBar.css";
 import ContextWindow from "./ContextWindow";
 import type { ChatSession } from "../models/home";
 import { apiDeleteChat } from "../api/home";
+import { ACTIVE_CHAT_SESSION } from "../pages/Home";
 
 interface PrevChatSideBarProps {
   chats: ChatSession[] | null;
@@ -84,7 +85,13 @@ export default function PrevChatSideBar({
                 <li
                   key={chat.id}
                   className={chat.id === activeChatId ? "active" : ""}
-                  onClick={() => onSelectChat(chat.id)}
+                  onClick={() => {
+                    onSelectChat(chat.id);
+                    sessionStorage.setItem(
+                      ACTIVE_CHAT_SESSION,
+                      chat.id.toString()
+                    );
+                  }}
                 >
                   <span className="chat-title">{chat.title}</span>
                   <button

--- a/frontend/src/pages/Account.tsx
+++ b/frontend/src/pages/Account.tsx
@@ -3,6 +3,7 @@ import { apiLogout } from "../api/account";
 import { useContext, type Context } from "react";
 import { GlobalContext } from "../helpers/global";
 import type { GlobalState } from "../components/GlobalProvider";
+import { ACTIVE_CHAT_SESSION } from "./Home";
 
 export default function Account() {
   const { setAuthorized } = useContext<GlobalState>(
@@ -16,6 +17,7 @@ export default function Account() {
       console.error("Logout failed with status", status);
     }
     setAuthorized(false);
+    sessionStorage.removeItem(ACTIVE_CHAT_SESSION);
   };
 
   return (


### PR DESCRIPTION
## Description
<!-- What does this PR change or add? -->
* Uses session storage to store the most recently used chat session id
* Chat id is cleared when creating a new chat
* Chat id is switched when you click on a different chat
* Refreshing the page keeps you on the same chat
* Going to a different page then going back to home keeps you on the same chat
* Closing the tab and opening the app again clears the chat id

## Related Issue(s)
<!-- Link the issue(s) this PR addresses -->
* Story: #177
* Epic: #74

## Testing
<!-- Steps to verify this PR works as intended -->
- [x] Local build/run works

## Checklist
- [x] Linked to Epic (if applicable)