### PR TITLE
added rename chat button to context window

### DIFF
--- a/frontend/src/components/ContextWindow.tsx
+++ b/frontend/src/components/ContextWindow.tsx
@@ -6,13 +6,15 @@ interface ContextWindowProps {
   y: number;
   onClose: () => void;
   onDelete: () => void;
+  onRename: () => void;
 }
 
 export default function ContextWindow({
   x,
   y,
   onClose,
-  onDelete
+  onDelete,
+  onRename
 }: ContextWindowProps) {
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -44,7 +46,10 @@ export default function ContextWindow({
       className="context-window"
       style={{ top: `${y}px`, left: `${x}px` }}
     >
-      <button className="context-menu-item" onClick={onDelete}>
+      <button className="context-menu-item rename" onClick={onRename}>
+        Rename
+      </button>
+      <button className="context-menu-item delete" onClick={onDelete}>
         Delete
       </button>
     </div>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -269,6 +269,16 @@ export default function Home() {
     });
   };
 
+  const handleRenameChat = (chatId: number, newTitle: string) => {
+    // Update the chat title in the chats list
+    setChats((prevChats) => {
+      if (!prevChats) return prevChats;
+      return prevChats.map((chat) =>
+        chat.id === chatId ? { ...chat, title: newTitle } : chat
+      );
+    });
+  };
+
   const handleToggleSidebar = () => {
     setSidebarVisible((prev) => !prev);
   };
@@ -294,6 +304,7 @@ export default function Home() {
           onNewChat={handleNewChat}
           onToggleSidebar={handleToggleSidebar}
           onDeleteChat={handleDeleteChat}
+          onRenameChat={handleRenameChat}
           sidebarVisible={sidebarVisible}
         />
 

--- a/frontend/src/styles/ContextWindow.css
+++ b/frontend/src/styles/ContextWindow.css
@@ -17,20 +17,40 @@
   text-align: left;
   cursor: pointer;
   font-size: 0.9rem;
-  color: #fa8072;
   border-radius: 6px;
   transition: all 0.2s;
   font-weight: 600;
 }
 
-.context-menu-item:hover {
+.context-menu-item.rename {
+  color: #30A0E0;
+}
+
+.context-menu-item.rename:hover {
+  background: linear-gradient(135deg, #30A0E0 0%, #4db3ed 100%);
+  color: white;
+  box-shadow: 0 2px 4px rgba(48, 160, 224, 0.2);
+  transform: translateY(-1px);
+}
+
+.context-menu-item.rename:active {
+  background: linear-gradient(135deg, #2a8fc7 0%, #30A0E0 100%);
+  transform: translateY(0);
+  box-shadow: 0 1px 2px rgba(48, 160, 224, 0.2);
+}
+
+.context-menu-item.delete {
+  color: #fa8072;
+}
+
+.context-menu-item.delete:hover {
   background: linear-gradient(135deg, #fa8072 0%, #ff9b8a 100%);
   color: white;
   box-shadow: 0 2px 4px rgba(250, 128, 114, 0.2);
   transform: translateY(-1px);
 }
 
-.context-menu-item:active {
+.context-menu-item.delete:active {
   background: linear-gradient(135deg, #e56b5d 0%, #fa8072 100%);
   transform: translateY(0);
   box-shadow: 0 1px 2px rgba(250, 128, 114, 0.2);

--- a/frontend/src/styles/PrevChatSideBar.css
+++ b/frontend/src/styles/PrevChatSideBar.css
@@ -244,3 +244,22 @@
   text-align: center;
   padding: 0 1rem;
 }
+
+.chat-title-input {
+  flex: 1;
+  background: rgba(255, 255, 255, 0.9);
+  border: 2px solid #30A0E0;
+  border-radius: 4px;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #333;
+  outline: none;
+  width: 100%;
+  box-shadow: 0 0 0 3px rgba(48, 160, 224, 0.1);
+}
+
+.chat-title-input:focus {
+  border-color: #2a8fc7;
+  box-shadow: 0 0 0 3px rgba(48, 160, 224, 0.2);
+}


### PR DESCRIPTION
## Description
adds rename chat functionality to the context window from clicking on the "..." button in prev chat side bar.
when a chat is renamed, it will be the last chat in the prev chat side bar on refresh. making it stay in place will require more changes

## Related Issue(s)
<!-- Link the issue(s) this PR addresses -->
* #176 

## Testing
<!-- Steps to verify this PR works as intended -->

- [ ] Tests added/updated
- [ ] Local build/run works

## Checklist
- [ ] Documentation updated (if needed)
- [x] #74 

<img width="1883" height="898" alt="image" src="https://github.com/user-attachments/assets/ae14fc6c-9120-4d6c-af5a-27daff853a6e" />

<img width="1885" height="893" alt="image" src="https://github.com/user-attachments/assets/63898302-b92f-458b-a441-0eed486feee9" />

