### PR TITLE
Fixed preference poppup logic

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -104,10 +104,11 @@ export default function Home() {
             return;
           }
           setShowFinishPopup(
-            account.budget_preference === null ||
-              account.disabilities === null ||
-              account.food_allergies === null ||
-              account.risk_preference === null
+            account.budget_preference === null &&
+            account.disabilities === "" &&
+            account.food_allergies === "" &&
+            account.risk_preference === null
+
           );
         })
         .catch((err) => {

--- a/frontend/src/pages/Preferences.tsx
+++ b/frontend/src/pages/Preferences.tsx
@@ -54,12 +54,10 @@ export default function Preferences() {
   const location = useLocation();
 
   const [loaded, setLoaded] = useState<boolean>(false);
-  const [budget, setBudget] = useState<BudgetBucket>(BudgetBucket.MediumBudget);
-  const [riskTolerance, setRiskTolerance] = useState<RiskTolerence>(
-    RiskTolerence.LightFun
-  );
-  const [disabilities, setDisabilities] = useState("");
-  const [foodPreferences, setFoodPreferences] = useState("");
+  const [budget, setBudget] = useState<BudgetBucket | null>(null);
+  const [riskTolerance, setRiskTolerance] = useState<RiskTolerence | null>(null);
+  const [disabilities, setDisabilities] = useState<string | null>(null);
+  const [foodPreferences, setFoodPreferences] = useState<string | null>(null);
   const [isEditingBudget, setIsEditingBudget] = useState<boolean>(false);
   const [isEditingRisk, setIsEditingRisk] = useState<boolean>(false);
   const [isEditingDisabilities, setIsEditingDisabilities] =
@@ -289,15 +287,20 @@ export default function Preferences() {
                         {isEditingBudget ? (
                           <select
                             id="budget"
-                            value={enumToString(BudgetBucket, budget)}
+                            value={budget ? enumToString(BudgetBucket, budget) : ""}
                             onChange={(e) => {
                               const key = e.target.value;
-                              const newVal = stringToEnum(BudgetBucket, key);
-                              if (newVal !== undefined) {
-                                setBudget(newVal as BudgetBucket);
+                              if (key === "") {
+                                setBudget(null);
+                              } else {
+                                const newVal = stringToEnum(BudgetBucket, key);
+                                if (newVal !== undefined) {
+                                  setBudget(newVal as BudgetBucket);
+                                }
                               }
                             }}
                           >
+                            <option value="">Select budget...</option>
                             {budgetOptions.map((option) => (
                               <option key={option} value={option}>
                                 {option}
@@ -306,7 +309,7 @@ export default function Preferences() {
                           </select>
                         ) : (
                           <div className="field-row__value">
-                            {enumToString(BudgetBucket, budget)}
+                            {budget ? enumToString(BudgetBucket, budget) : "—"}
                           </div>
                         )}
                       </div>
@@ -337,15 +340,20 @@ export default function Preferences() {
                         {isEditingRisk ? (
                           <select
                             id="riskTolerance"
-                            value={enumToString(RiskTolerence, riskTolerance)}
+                            value={riskTolerance ? enumToString(RiskTolerence, riskTolerance) : ""}
                             onChange={(e) => {
                               const key = e.target.value;
-                              const newVal = stringToEnum(RiskTolerence, key);
-                              if (newVal !== undefined) {
-                                setRiskTolerance(newVal as RiskTolerence);
+                              if (key === "") {
+                                setRiskTolerance(null);
+                              } else {
+                                const newVal = stringToEnum(RiskTolerence, key);
+                                if (newVal !== undefined) {
+                                  setRiskTolerance(newVal as RiskTolerence);
+                                }
                               }
                             }}
                           >
+                            <option value="">Select risk tolerance...</option>
                             {riskOptions.map((option) => (
                               <option key={option} value={option}>
                                 {option}
@@ -354,7 +362,7 @@ export default function Preferences() {
                           </select>
                         ) : (
                           <div className="field-row__value">
-                            {enumToString(RiskTolerence, riskTolerance)}
+                            {riskTolerance ? enumToString(RiskTolerence, riskTolerance) : "—"}
                           </div>
                         )}
                       </div>
@@ -387,7 +395,7 @@ export default function Preferences() {
                         {isEditingDisabilities ? (
                           <textarea
                             id="disabilities"
-                            value={disabilities}
+                            value={disabilities ?? ""}
                             onChange={(e) => setDisabilities(e.target.value)}
                             placeholder="e.g., Wheelchair user, visual impairment."
                           />
@@ -426,7 +434,7 @@ export default function Preferences() {
                         {isEditingFood ? (
                           <textarea
                             id="foodPreferences"
-                            value={foodPreferences}
+                            value={foodPreferences ?? ""}
                             onChange={(e) => setFoodPreferences(e.target.value)}
                             placeholder="e.g., Gluten-free, no shellfish, vegan."
                           />


### PR DESCRIPTION
…pty. filling out just one of them will make it go away

## Description
Preference dialogue will only pop up if all fields are empty. If one of them is filled out it will not popup again.

## Related Issue(s)
<!-- Link the issue(s) this PR addresses -->
* #199 

## Testing
<!-- Steps to verify this PR works as intended -->

- [ ] Tests added/updated
- [ ] Local build/run works

## Checklist
- [ ] Documentation updated (if needed)
- [ ] Linked to Epic (if applicable)


<img width="1140" height="512" alt="image" src="https://github.com/user-attachments/assets/f3027793-3425-4ef0-8be2-1c2d9aa4902a" />

<img width="874" height="382" alt="image" src="https://github.com/user-attachments/assets/081fa37d-5d6f-4fcb-a4cf-f611a6a6cbfe" />

<img width="813" height="329" alt="image" src="https://github.com/user-attachments/assets/f61bbf4d-42ef-4fca-aa4c-b04ab19152e5" />

<img width="1243" height="573" alt="image" src="https://github.com/user-attachments/assets/260e2a49-5c0a-456e-afdd-3175d11be306" />

